### PR TITLE
docs: Add command copy .env.example to .env, running npm run dev after php artisan serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,13 @@ Run the following command to create a new Velstore project:
 composer create-project velstorelabs/velstore
 ```
 
-Create a new database, then rename `.env.example` to `.env` and update the database credentials. Run the following command to install Velstore:
+If you didn't have `.env` you can copy it from `.env.example`.
+
+```sh
+cp .env.example .env
+```
+
+Create a new database and update the database credentials in `.env`. Run the following command to install Velstore:
 ```sh
 php artisan install:velstore --with-import
 ```
@@ -59,6 +65,11 @@ php artisan install:velstore --with-import
 Start the Laravel server:
 ```sh
 php artisan serve
+```
+
+If you found error `Vite manifest not found at`, you should run this in different terminal:
+```sh
+npm run dev
 ```
 
 Your Velstore instance is now running! Open your browser and visit:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "velstore",
+    "name": "velstore-repo",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {


### PR DESCRIPTION
## Description:
I add command to copy .env.example to .env if some people lazy to copy with mouse. After that, add command to run `npm run dev` in different terminal.

## Motivation and Context
Because, when I'm use `php artisan serve` without `npm run dev`. I found error about vite manifest.
![Screenshot 2025-04-23 173420](https://github.com/user-attachments/assets/dcd85171-919f-44a5-9dca-88cc7511c9b9)

## Type of Change
Docs

